### PR TITLE
sphinx.util.compat.Directive class is now deprecated in sphinx 1.6b1

### DIFF
--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -47,7 +47,7 @@ from sphinx.locale import l_, _
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
-from sphinx.util.compat import Directive
+# from sphinx.util.compat import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField, DocFieldTransformer, _is_single_paragraph
 
 # FIXME: surlignage en jaune de la recherche inactive si "/" dans target


### PR DESCRIPTION
Hi,

sphinx-build (version 1.7.1) generates an error with the  fortran domain:

Could not import extension sphinxfortran.fortran_domain (exception: cannot import name Directive)

It comes from the line : 
File "sphinxfortran/fortran_domain.py", line 50, in <module>
    from sphinx.util.compat import Directive
ImportError: cannot import name Directive


According to http://www.sphinx-doc.org/en/stable/changes.html?highlight=sphinx.util.compat,
the sphinx.util.compat.Directive class is deprecated.

So I just comment this line and it works on my examples.
