### PR TITLE
First attempt at Python3 compatibility

### DIFF
--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -52,6 +52,11 @@ from sphinx.util.docfields import Field, GroupedField, TypedField, DocFieldTrans
 
 import six
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 # FIXME: surlignage en jaune de la recherche inactive si "/" dans target
 
 # Utilities


### PR DESCRIPTION
I just worked through all the Python3 errors until I got something working. Broad changes include:

- brackets for print statements,
- casting iterables as lists so they can be added, and
- removing dictionary sorts, which seem to be unsupported in Python 3.

So far (at least with my code) it appears to preserve Python 2 functionality (except for the loss of those `dict.sort()` statements).