### PR TITLE
Fix optional arguments not declared with a o:

### DIFF
--- a/sphinxfortran/fortran_autodoc.py
+++ b/sphinxfortran/fortran_autodoc.py
@@ -1011,8 +1011,7 @@ class F90toRst(object):
                 newattrs.append('default=' + default_value)
             if 'private' in newattrs and 'public' in newattrs:
                 newattrs.remove('private')
-            block['attrspec'] = newattrs
-            vattr.append('/'.join(block['attrspec']))
+            vattr.append('/'.join(newattrs))
         if not vattr:
             return ''
         vattr = ','.join(vattr)
@@ -1042,7 +1041,7 @@ class F90toRst(object):
             vdim = vdim.replace(':', '*')
         vattr = self.format_argattr(blockvar)
         vdesc = blockvar['desc'] if 'desc' in blockvar else ''
-        optional = 'attrspec' in blockvar and 'optional' in blockvar['attrspec']
+        optional = 'attrspec' in blockvar and 'optional' in blockvar['attrspec'] and 'depend' not in blockvar
         if not role:
             if block and vname in [block['name'], block.get('result')]:
                 role = 'r'

--- a/tests/references/test-fortran-autodoc/module_assim.xml
+++ b/tests/references/test-fortran-autodoc/module_assim.xml
@@ -86,20 +86,23 @@
                                         ]
                                      :: 
                                     sign of the exponent
-                            <list_item>
-                                <paragraph>
-                                    <strong>
-                                        printinformation_opt
-                                    <emphasis>
-                                         [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="logical" reftype="type" typename="">
-                                        <emphasis>
-                                            logical
-                                    <emphasis>
-                                        ,
-                                    <emphasis>
-                                        in,
-                                    <emphasis>
-                                        ]
-                                     :: 
-                                    request more verbose output
+                <field>
+                    <field_name>
+                        Options
+                    <field_body>
+                        <paragraph>
+                            <strong>
+                                printinformation_opt
+                            <emphasis>
+                                 [
+                            <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="logical" reftype="type" typename="">
+                                <emphasis>
+                                    logical
+                            <emphasis>
+                                ,
+                            <emphasis>
+                                in,
+                            <emphasis>
+                                ]
+                             :: 
+                            request more verbose output

--- a/tests/references/test-fortran-autodoc/module_generic.xml
+++ b/tests/references/test-fortran-autodoc/module_generic.xml
@@ -321,9 +321,6 @@
                         <emphasis>
                             parameter=
                         100
-                        /
-                        <pending_xref modname="generic" refdomain="f" reftarget="default" reftype="var">
-                            default
                         <emphasis>
                             ]
                     <desc_content>


### PR DESCRIPTION
Changing the 'attrspec' array in block in format_argattr(), makes the test on optional in `format_argfield()` to fail. No optional parameters are then declared with `o:`, but all with `p:`.
This MR is fixing the issue (and not detecting optional arguments by looking at the 'depend' stuff that is added by crackfortran) and updating the references since some arguments are now declared in the optional list.