### PR TITLE
Don't list types in variable index

### DIFF
--- a/sphinxfortran/fortran_autodoc.py
+++ b/sphinxfortran/fortran_autodoc.py
@@ -226,7 +226,7 @@ class F90toRst(object):
                 # Module variables
                 for varname in sorted(block['sortvars']):
                     bvar = block['vars'][varname]
-                    if varname not in self.routines:
+                    if varname not in self.routines and varname not in self.types:
                         self.variables[varname] = bvar
                         # self.variables.pop(varname)
                         bvar['name'] = varname


### PR DESCRIPTION
Currently, type declarations are also listed as variables.