### PR TITLE
Add parallel read support for fortran_domain sphinx extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -54,6 +54,8 @@ from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
 from sphinx.util.docfields import Field, GroupedField, TypedField, DocFieldTransformer, _is_single_paragraph
 
+from typing import (Any, Callable, Dict, Generator, Iterator, List, Tuple, Type, TypeVar, Union, Optional)
+
 import six
 
 
@@ -1256,6 +1258,19 @@ class FortranDomain(Domain):
             matches.append((newname, objects[newname]))
         return matches
 
+    def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:
+        ourNames = self.data['modules']
+        for name, docname in otherdata['modules'].items():
+            if docname in docnames:
+                if name not in outNames:
+                    outNames[name] = docname
+
+        ourNames = self.data['objects']
+        for name, docname in otherdata['objects'].items():
+            if docname in docnames:
+                if name not in outNames:
+                    outNames[name] = docname
+
     def resolve_xref(self, env, fromdocname, builder,
                      type, target, node, contnode):
         modname = node.get('f:module', node.get('modname'))
@@ -1299,3 +1314,4 @@ class FortranDomain(Domain):
 
 def setup(app):
     app.add_domain(FortranDomain)
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 
 Adapted from sphinx/tests/conftest.py.
 """
-
+from __future__ import print_function
 import os
 import shutil
 import sys

--- a/tests/references/test-fortran-autodoc/misc_routines.xml
+++ b/tests/references/test-fortran-autodoc/misc_routines.xml
@@ -3,10 +3,10 @@
         Misc routines
     <index entries="('single',\ 'calc_distance()\ (fortran\ subroutine)',\ 'f/_/calc_distance',\ 'f/_/calc_distance',\ None)">
     <desc desctype="subroutine" domain="f" noindex="False" objtype="subroutine">
-        <desc_signature first="False" fullname="_/calc_distance" ids="f/_/calc_distance" module="True" names="f/_/calc_distance" type="">
+        <desc_signature classes="sig sig-object" first="False" fullname="_/calc_distance" ids="f/_/calc_distance" module="True" names="f/_/calc_distance" type="">
             <desc_annotation xml:space="preserve">
                 subroutine  
-            <desc_name xml:space="preserve">
+            <desc_name classes="sig-name descname" xml:space="preserve">
                 calc_distance
             <desc_parameterlist xml:space="preserve">
                 <desc_parameter xml:space="preserve">

--- a/tests/references/test-fortran-autodoc/module_assim.xml
+++ b/tests/references/test-fortran-autodoc/module_assim.xml
@@ -3,10 +3,10 @@
         Assimilation module
     <index entries="('single',\ 'utl_matsqrt()\ (fortran\ subroutine)',\ 'f/_/utl_matsqrt',\ 'f/_/utl_matsqrt',\ None)">
     <desc desctype="subroutine" domain="f" noindex="False" objtype="subroutine">
-        <desc_signature first="False" fullname="_/utl_matsqrt" ids="f/_/utl_matsqrt" module="True" names="f/_/utl_matsqrt" type="">
+        <desc_signature classes="sig sig-object" first="False" fullname="_/utl_matsqrt" ids="f/_/utl_matsqrt" module="True" names="f/_/utl_matsqrt" type="">
             <desc_annotation xml:space="preserve">
                 subroutine  
-            <desc_name xml:space="preserve">
+            <desc_name classes="sig-name descname" xml:space="preserve">
                 utl_matsqrt
             <desc_parameterlist xml:space="preserve">
                 <desc_parameter xml:space="preserve">

--- a/tests/references/test-fortran-autodoc/module_generic.xml
+++ b/tests/references/test-fortran-autodoc/module_generic.xml
@@ -46,12 +46,12 @@
             <list_item>
                 <index entries="('single',\ 'mytest\ (fortran\ type\ in\ module\ generic)',\ 'f/generic/mytest',\ 'f/generic/mytest',\ None)">
                 <desc desctype="type" domain="f" noindex="False" objtype="type">
-                    <desc_signature first="False" fullname="generic/mytest" ids="f/generic/mytest" module="generic" names="f/generic/mytest" type="">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/mytest" ids="f/generic/mytest" module="generic" names="f/generic/mytest" type="">
                         <desc_annotation xml:space="preserve">
                             type  
-                        <desc_addname xml:space="preserve">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             mytest
                     <desc_content>
                         <paragraph>
@@ -70,9 +70,9 @@
                                     <bullet_list>
                                         <list_item>
                                             <paragraph>
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     % 
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     arr
                                                  (
                                                 10
@@ -88,9 +88,9 @@
                                                 Array of fixed size
                                         <list_item>
                                             <paragraph>
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     % 
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     arr2
                                                  (
                                                 20
@@ -106,9 +106,9 @@
                                                 Array described in docstring
                                         <list_item>
                                             <paragraph>
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     % 
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     myint
                                                 <emphasis>
                                                      [
@@ -122,12 +122,12 @@
             <list_item>
                 <index entries="('single',\ 'mysecondtest\ (fortran\ type\ in\ module\ generic)',\ 'f/generic/mysecondtest',\ 'f/generic/mysecondtest',\ None)">
                 <desc desctype="type" domain="f" noindex="False" objtype="type">
-                    <desc_signature first="False" fullname="generic/mysecondtest" ids="f/generic/mysecondtest" module="generic" names="f/generic/mysecondtest" type="">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/mysecondtest" ids="f/generic/mysecondtest" module="generic" names="f/generic/mysecondtest" type="">
                         <desc_annotation xml:space="preserve">
                             type  
-                        <desc_addname xml:space="preserve">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             mysecondtest
                     <desc_content>
                         <paragraph>
@@ -137,11 +137,11 @@
         <bullet_list bullet="-">
             <list_item>
                 <index entries="('single',\ 'nens\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/nens',\ 'f/generic/nens',\ None)">
-                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature first="False" fullname="generic/nens" ids="f/generic/nens" module="generic" names="f/generic/nens" type="">
-                        <desc_addname xml:space="preserve">
+                <desc classes="f variable" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/nens" ids="f/generic/nens" module="generic" names="f/generic/nens" type="">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             nens
                         <emphasis>
                              [
@@ -160,11 +160,11 @@
                             Size of the ensemble
             <list_item>
                 <index entries="('single',\ 'sss\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sss',\ 'f/generic/sss',\ None)">
-                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature first="False" fullname="generic/sss" ids="f/generic/sss" module="generic" names="f/generic/sss" type="">
-                        <desc_addname xml:space="preserve">
+                <desc classes="f variable" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/sss" ids="f/generic/sss" module="generic" names="f/generic/sss" type="">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             sss
                          (
                         100
@@ -181,11 +181,11 @@
                             Sea surface salinity
             <list_item>
                 <index entries="('single',\ 'sst\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sst',\ 'f/generic/sst',\ None)">
-                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature first="False" fullname="generic/sst" ids="f/generic/sst" module="generic" names="f/generic/sst" type="">
-                        <desc_addname xml:space="preserve">
+                <desc classes="f variable" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/sst" ids="f/generic/sst" module="generic" names="f/generic/sst" type="">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             sst
                          (
                         100
@@ -248,12 +248,12 @@
             <list_item>
                 <index entries="('single',\ 'mytest\ (fortran\ type\ in\ module\ generic)',\ 'f/generic/mytest',\ 'f/generic/mytest',\ None)">
                 <desc desctype="type" domain="f" noindex="False" objtype="type">
-                    <desc_signature first="False" fullname="generic/mytest" module="generic" type="">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/mytest" module="generic" type="">
                         <desc_annotation xml:space="preserve">
                             type  
-                        <desc_addname xml:space="preserve">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             mytest
                     <desc_content>
                         <paragraph>
@@ -272,9 +272,9 @@
                                     <bullet_list>
                                         <list_item>
                                             <paragraph>
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     % 
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     arr
                                                  (
                                                 10
@@ -290,9 +290,9 @@
                                                 Array of fixed size
                                         <list_item>
                                             <paragraph>
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     % 
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     arr2
                                                  (
                                                 20
@@ -308,9 +308,9 @@
                                                 Array described in docstring
                                         <list_item>
                                             <paragraph>
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     % 
-                                                <desc_name xml:space="preserve">
+                                                <desc_name classes="sig-name descname" xml:space="preserve">
                                                     myint
                                                 <emphasis>
                                                      [
@@ -324,12 +324,12 @@
             <list_item>
                 <index entries="('single',\ 'mysecondtest\ (fortran\ type\ in\ module\ generic)',\ 'f/generic/mysecondtest',\ 'f/generic/mysecondtest',\ None)">
                 <desc desctype="type" domain="f" noindex="False" objtype="type">
-                    <desc_signature first="False" fullname="generic/mysecondtest" module="generic" type="">
+                    <desc_signature classes="sig sig-object" first="False" fullname="generic/mysecondtest" module="generic" type="">
                         <desc_annotation xml:space="preserve">
                             type  
-                        <desc_addname xml:space="preserve">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             mysecondtest
                     <desc_content>
                         <paragraph>
@@ -339,11 +339,11 @@
         <bullet_list bullet="-">
             <list_item>
                 <index entries="('single',\ 'nens\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/nens',\ 'f/generic/nens',\ None)">
-                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature fullname="generic/nens" module="generic" type="">
-                        <desc_addname xml:space="preserve">
+                <desc classes="f variable" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature classes="sig sig-object" fullname="generic/nens" module="generic" type="">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             nens
                         <emphasis>
                              [
@@ -362,11 +362,11 @@
                             Size of the ensemble
             <list_item>
                 <index entries="('single',\ 'sss\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sss',\ 'f/generic/sss',\ None)">
-                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature fullname="generic/sss" module="generic" type="">
-                        <desc_addname xml:space="preserve">
+                <desc classes="f variable" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature classes="sig sig-object" fullname="generic/sss" module="generic" type="">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             sss
                          (
                         100
@@ -383,11 +383,11 @@
                             Sea surface salinity
             <list_item>
                 <index entries="('single',\ 'sst\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sst',\ 'f/generic/sst',\ None)">
-                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature fullname="generic/sst" module="generic" type="">
-                        <desc_addname xml:space="preserve">
+                <desc classes="f variable" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature classes="sig sig-object" fullname="generic/sst" module="generic" type="">
+                        <desc_addname classes="sig-prename descclassname" xml:space="preserve">
                             generic/
-                        <desc_name xml:space="preserve">
+                        <desc_name classes="sig-name descname" xml:space="preserve">
                             sst
                          (
                         100

--- a/tests/roots/test-fortran-autodoc/conf.py
+++ b/tests/roots/test-fortran-autodoc/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import sys
 import os
 this_dir = os.path.dirname(__file__)
@@ -19,5 +20,5 @@ fortran_src = [os.path.abspath(os.path.join(this_dir, path))
                             'module_generic.f90',
                             'misc_routines.f90',
                             )]
-print fortran_src
+print(fortran_src)
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -63,7 +63,7 @@ def check_result(test_name, result):
 @pytest.mark.sphinx('dummy', testroot='fortran-autodoc')
 def test_autodoc_module_assim(app, status, warning):
     app.builder.build_all()
-    result = pickle.loads((app.doctreedir / 'module_assim.doctree').bytes())
+    result = pickle.loads((app.doctreedir / 'module_assim.doctree').read_bytes())
     check_result('module_assim', result)
 
 
@@ -80,12 +80,12 @@ def test_autodoc_module_assim(app, status, warning):
 @pytest.mark.sphinx('dummy', testroot='fortran-autodoc')
 def test_autodoc_module_generic(app, status, warning):
     app.builder.build_all()
-    result = pickle.loads((app.doctreedir / 'module_generic.doctree').bytes())
+    result = pickle.loads((app.doctreedir / 'module_generic.doctree').read_bytes())
     check_result('module_generic', result)
 
 
 @pytest.mark.sphinx('dummy', testroot='fortran-autodoc')
 def test_autodoc_misc_routines(app, status, warning):
     app.builder.build_all()
-    result = pickle.loads((app.doctreedir / 'misc_routines.doctree').bytes())
+    result = pickle.loads((app.doctreedir / 'misc_routines.doctree').read_bytes())
     check_result('misc_routines', result)


### PR DESCRIPTION
Got annoyed by the recurring message about the `fortran domain` in sphinx-fortran not signaling whether it supports parallel reading. So I went ahead, looked at a few sphinx extensions and added a few lines of code that a) silence the warnings and b) seem to be supporting parallel reads, too. I'm not sphinx hacker, so there may be bugs hiding, but it works for my use cases.