### PR TITLE
Fixes #35: Fatal error when documenting multiple types in the same file.

### DIFF
--- a/sphinxfortran/fortran_autodoc.py
+++ b/sphinxfortran/fortran_autodoc.py
@@ -1249,7 +1249,7 @@ class F90toRst(object):
 
         # Types
         decs = []
-        tlist = sorted(self.get_blocklist('types', module))
+        tlist = self.get_blocklist('types', module)
         if tlist:
             decs.append(':Types: ' +
                         ', '.join([':f:type:`%s`' %

--- a/tests/references/test-fortran-autodoc/module_generic.xml
+++ b/tests/references/test-fortran-autodoc/module_generic.xml
@@ -17,6 +17,10 @@
                     Types
                 <field_body>
                     <paragraph>
+                        <pending_xref f:module="generic" f:type="True" refdoc="module_generic" refdomain="f" refexplicit="False" reftarget="mysecondtest" reftype="type" refwarn="False">
+                            <literal classes="xref f f-type">
+                                mysecondtest
+                        , 
                         <pending_xref f:module="generic" f:type="True" refdoc="module_generic" refdomain="f" refexplicit="False" reftarget="mytest" reftype="type" refwarn="False">
                             <literal classes="xref f f-type">
                                 mytest
@@ -115,12 +119,25 @@
                                                     ]
                                                  :: 
                                                 Description of myint
+            <list_item>
+                <index entries="('single',\ 'mysecondtest\ (fortran\ type\ in\ module\ generic)',\ 'f/generic/mysecondtest',\ 'f/generic/mysecondtest',\ None)">
+                <desc desctype="type" domain="f" noindex="False" objtype="type">
+                    <desc_signature first="False" fullname="generic/mysecondtest" ids="f/generic/mysecondtest" module="generic" names="f/generic/mysecondtest" type="">
+                        <desc_annotation xml:space="preserve">
+                            type  
+                        <desc_addname xml:space="preserve">
+                            generic/
+                        <desc_name xml:space="preserve">
+                            mysecondtest
+                    <desc_content>
+                        <paragraph>
+                            Description of my second type
         <rubric>
             Variables
         <bullet_list bullet="-">
             <list_item>
                 <index entries="('single',\ 'nens\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/nens',\ 'f/generic/nens',\ None)">
-                <desc desctype="variable" domain="f" noindex="False" objtype="variable">
+                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
                     <desc_signature first="False" fullname="generic/nens" ids="f/generic/nens" module="generic" names="f/generic/nens" type="">
                         <desc_addname xml:space="preserve">
                             generic/
@@ -143,7 +160,7 @@
                             Size of the ensemble
             <list_item>
                 <index entries="('single',\ 'sss\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sss',\ 'f/generic/sss',\ None)">
-                <desc desctype="variable" domain="f" noindex="False" objtype="variable">
+                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
                     <desc_signature first="False" fullname="generic/sss" ids="f/generic/sss" module="generic" names="f/generic/sss" type="">
                         <desc_addname xml:space="preserve">
                             generic/
@@ -164,7 +181,7 @@
                             Sea surface salinity
             <list_item>
                 <index entries="('single',\ 'sst\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sst',\ 'f/generic/sst',\ None)">
-                <desc desctype="variable" domain="f" noindex="False" objtype="variable">
+                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
                     <desc_signature first="False" fullname="generic/sst" ids="f/generic/sst" module="generic" names="f/generic/sst" type="">
                         <desc_addname xml:space="preserve">
                             generic/
@@ -202,6 +219,10 @@
                     Types
                 <field_body>
                     <paragraph>
+                        <pending_xref f:module="generic" f:type="True" refdoc="module_generic" refdomain="f" refexplicit="False" reftarget="mysecondtest" reftype="type" refwarn="False">
+                            <literal classes="xref f f-type">
+                                mysecondtest
+                        , 
                         <pending_xref f:module="generic" f:type="True" refdoc="module_generic" refdomain="f" refexplicit="False" reftarget="mytest" reftype="type" refwarn="False">
                             <literal classes="xref f f-type">
                                 mytest
@@ -300,13 +321,26 @@
                                                     ]
                                                  :: 
                                                 Description of myint
+            <list_item>
+                <index entries="('single',\ 'mysecondtest\ (fortran\ type\ in\ module\ generic)',\ 'f/generic/mysecondtest',\ 'f/generic/mysecondtest',\ None)">
+                <desc desctype="type" domain="f" noindex="False" objtype="type">
+                    <desc_signature first="False" fullname="generic/mysecondtest" module="generic" type="">
+                        <desc_annotation xml:space="preserve">
+                            type  
+                        <desc_addname xml:space="preserve">
+                            generic/
+                        <desc_name xml:space="preserve">
+                            mysecondtest
+                    <desc_content>
+                        <paragraph>
+                            Description of my second type
         <rubric>
             Variables
         <bullet_list bullet="-">
             <list_item>
                 <index entries="('single',\ 'nens\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/nens',\ 'f/generic/nens',\ None)">
-                <desc desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature first="False" fullname="generic/nens" module="generic" type="">
+                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature fullname="generic/nens" module="generic" type="">
                         <desc_addname xml:space="preserve">
                             generic/
                         <desc_name xml:space="preserve">
@@ -328,8 +362,8 @@
                             Size of the ensemble
             <list_item>
                 <index entries="('single',\ 'sss\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sss',\ 'f/generic/sss',\ None)">
-                <desc desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature first="False" fullname="generic/sss" module="generic" type="">
+                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature fullname="generic/sss" module="generic" type="">
                         <desc_addname xml:space="preserve">
                             generic/
                         <desc_name xml:space="preserve">
@@ -349,8 +383,8 @@
                             Sea surface salinity
             <list_item>
                 <index entries="('single',\ 'sst\ (fortran\ variable\ in\ module\ generic)',\ 'f/generic/sst',\ 'f/generic/sst',\ None)">
-                <desc desctype="variable" domain="f" noindex="False" objtype="variable">
-                    <desc_signature first="False" fullname="generic/sst" module="generic" type="">
+                <desc classes="f" desctype="variable" domain="f" noindex="False" objtype="variable">
+                    <desc_signature fullname="generic/sst" module="generic" type="">
                         <desc_addname xml:space="preserve">
                             generic/
                         <desc_name xml:space="preserve">

--- a/tests/roots/test-fortran-autodoc/module_generic.f90
+++ b/tests/roots/test-fortran-autodoc/module_generic.f90
@@ -17,4 +17,9 @@ type mytest
 
 end type mytest
 
+type mysecondtest
+    ! Description of my second type
+
+end type mysecondtest
+
 end module generic


### PR DESCRIPTION
The issue stems from trying to sort dictionaries using the `sorted()` function, which is apparently unsupported. This occurs in `format_quickaccess` method, so it's probably better to simply remove the call to `sorted()`, and leave this job to `get_blocklist` method, where `sort` parameter defaults to `True` anyway.

Extended test and added the test case to module file. Synced the generic module reference so the tests pass locally.

Any questions, please let me know. Thanks!