### PR TITLE
Fix for correct rendering of dimensions of allocatable arrays

### DIFF
--- a/sphinxfortran/fortran_autodoc.py
+++ b/sphinxfortran/fortran_autodoc.py
@@ -1045,7 +1045,7 @@ class F90toRst(object):
 
         vdim = self.format_argdim(blockvar)
         if ':' in vdim:
-            vdim = vdim.replace(':', '*')
+            vdim = vdim.replace(':', '\*')
         vattr = self.format_argattr(blockvar)
         vdesc = blockvar['desc'] if 'desc' in blockvar else ''
         optional = 'attrspec' in blockvar and 'optional' in blockvar['attrspec'] and 'depend' not in blockvar

--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -106,8 +106,13 @@ def add_shape(node, shape, modname=None, nodefmt=nodes.Text):
 
 re_name_shape = re.compile(r'(\w+)(\(.+\))?')
 
+# The regular expression to get the different arg fields from :param:
+# Make double precision an acceptable type
+# re_fieldname_match = re.compile(
+#     r'(?P<type>\b(?:double precision|\w+)\b(?P<kind>\s*\(.*\))?)?\s*(?P<name>\b\w+\b)\s*(?P<shape>\(.*\))?\s*(?P<sattrs>\[.+\])?').match
+# Accept all types in two words
 re_fieldname_match = re.compile(
-    r'(?P<type>\b\w+\b(?P<kind>\s*\(.*\))?)?\s*(?P<name>\b\w+\b)\s*(?P<shape>\(.*\))?\s*(?P<sattrs>\[.+\])?').match
+    r'(?P<type>\b\w+ ?(?:\w+)?\b(?P<kind>\s*\(.*\))?)?\s*(?P<name>\b\w+\b)\s*(?P<shape>\(.*\))?\s*(?P<sattrs>\[.+\])?').match
 
 
 class FortranField(Field):

--- a/tests/roots/test-fortran-autodoc/conf.py
+++ b/tests/roots/test-fortran-autodoc/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import sys
 import os
 this_dir = os.path.dirname(__file__)
@@ -19,5 +20,5 @@ fortran_src = [os.path.abspath(os.path.join(this_dir, path))
                             'module_generic.f90',
                             'misc_routines.f90',
                             )]
-print fortran_src
+print(fortran_src)
 


### PR DESCRIPTION
Hi,
I'd like to propose a fix to improve the rendering of the dimensions of allocatable dummy arguments in the sphinx documentation. When replacing `':' `by `'\*'` in the dimensions, the star character is correctly rendered, while without the anti-slash the star is later interpreted as `<emphasis>`. 

BTW: Are there any plans for a release on pypi containing the very useful contributions from Damien Caliste?

Best regards,
Sabine
