### PR TITLE
Accept fortran types in two words (e.g. double precision)

### DIFF
--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -106,8 +106,13 @@ def add_shape(node, shape, modname=None, nodefmt=nodes.Text):
 
 re_name_shape = re.compile(r'(\w+)(\(.+\))?')
 
+# The regular expression to get the different arg fields from :param:
+# Make double precision an acceptable type
+# re_fieldname_match = re.compile(
+#     r'(?P<type>\b(?:double precision|\w+)\b(?P<kind>\s*\(.*\))?)?\s*(?P<name>\b\w+\b)\s*(?P<shape>\(.*\))?\s*(?P<sattrs>\[.+\])?').match
+# Accept all types in two words
 re_fieldname_match = re.compile(
-    r'(?P<type>\b\w+\b(?P<kind>\s*\(.*\))?)?\s*(?P<name>\b\w+\b)\s*(?P<shape>\(.*\))?\s*(?P<sattrs>\[.+\])?').match
+    r'(?P<type>\b\w+ ?(?:\w+)?\b(?P<kind>\s*\(.*\))?)?\s*(?P<name>\b\w+\b)\s*(?P<shape>\(.*\))?\s*(?P<sattrs>\[.+\])?').match
 
 
 class FortranField(Field):


### PR DESCRIPTION
Hi,
With the precious help from my colleague Léo Viallon-Galinier, I'd like to propose a fix for issue #38.
Best regards,
Sabine