### PR TITLE
Changes to use Sphinx logging API

### DIFF
--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -51,11 +51,15 @@ from sphinx.roles import XRefRole
 from sphinx.locale import _
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
+from sphinx.util import logging
 from sphinx.util.nodes import make_refnode
 from sphinx.util.docfields import Field, GroupedField, TypedField, DocFieldTransformer, _is_single_paragraph
 
 import six
 
+# Set up logging
+
+logger = logging.getLogger(__name__)
 
 # FIXME: surlignage en jaune de la recherche inactive si "/" dans target
 
@@ -697,12 +701,9 @@ class FortranObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
             objects = self.env.domaindata['f']['objects']
             if fullname in objects:
-                self.env.warn(
-                    self.env.docname,
-                    'duplicate object description of %s, ' % fullname +
-                    'other instance in ' +
-                    self.env.doc2path(objects[fullname][0]),
-                    self.lineno)
+                logger.warning(f'duplicate object description of {fullname}, other instance in '+
+                               self.env.doc2path(objects[fullname][0]),
+                               location=(self.env.docname, self.lineno))
             objects[fullname] = (self.env.docname, self.objtype)
         indextext = self.get_index_text(modname, fullname)
         if indextext:

--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -1266,11 +1266,11 @@ class FortranDomain(Domain):
         if not matches:
             return None
         elif len(matches) > 1:
-            env.warn(fromdocname,
-                     'more than one target found for cross-reference '
-                     '%r: %s' % (target,
-                                 ', '.join(match[0] for match in matches)),
-                     node.line)
+            logger.warning(
+                'more than one target found for cross-reference '
+                '%r: %s' % (target,
+                            ', '.join(match[0] for match in matches)),
+                location=(fromdocname, node.line))
         name, obj = matches[0]
 
         if obj[1] == 'module':


### PR DESCRIPTION
The `BuildEnvironment.warn` method has been deprecated since Sphinx 1.6, and was deleted in 2.0. This PR makes small changes to use the Sphinx logging API instead.