### PR TITLE
Update test references following b2d6ced

### DIFF
--- a/tests/references/test-fortran-autodoc/misc_routines.xml
+++ b/tests/references/test-fortran-autodoc/misc_routines.xml
@@ -43,9 +43,9 @@
                                         np
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                         <emphasis>
-                                            integer
+                                            integer 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -60,9 +60,9 @@
                                         nd
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                         <emphasis>
-                                            integer
+                                            integer 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -84,9 +84,9 @@
                                     )
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                         <emphasis>
-                                            real
+                                            real 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -101,9 +101,9 @@
                                         i
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                         <emphasis>
-                                            integer
+                                            integer 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -118,9 +118,9 @@
                                         j
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                         <emphasis>
-                                            integer
+                                            integer 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -139,9 +139,9 @@
                                     )
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                         <emphasis>
-                                            real
+                                            real 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -156,9 +156,9 @@
                                         d
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                         <emphasis>
-                                            real
+                                            real 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -173,9 +173,9 @@
                                         d2
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                         <emphasis>
-                                            real
+                                            real 
                                     <emphasis>
                                         ,
                                     <emphasis>

--- a/tests/references/test-fortran-autodoc/module_assim.xml
+++ b/tests/references/test-fortran-autodoc/module_assim.xml
@@ -41,9 +41,9 @@
                                     )
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                         <emphasis>
-                                            real
+                                            real 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -58,9 +58,9 @@
                                         kn
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                         <emphasis>
-                                            integer
+                                            integer 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -75,9 +75,9 @@
                                         zsign
                                     <emphasis>
                                          [
-                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                    <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                         <emphasis>
-                                            real
+                                            real 
                                     <emphasis>
                                         ,
                                     <emphasis>
@@ -95,9 +95,9 @@
                                 printinformation_opt
                             <emphasis>
                                  [
-                            <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="logical" reftype="type" typename="">
+                            <pending_xref modname="True" refdomain="f" refexplicit="False" reftarget="logical " reftype="type" typename="">
                                 <emphasis>
-                                    logical
+                                    logical 
                             <emphasis>
                                 ,
                             <emphasis>

--- a/tests/references/test-fortran-autodoc/module_generic.xml
+++ b/tests/references/test-fortran-autodoc/module_generic.xml
@@ -79,9 +79,9 @@
                                                 )
                                                 <emphasis>
                                                      [
-                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                                     <emphasis>
-                                                        real
+                                                        real 
                                                 <emphasis>
                                                     ]
                                                  :: 
@@ -97,9 +97,9 @@
                                                 )
                                                 <emphasis>
                                                      [
-                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                                     <emphasis>
-                                                        real
+                                                        real 
                                                 <emphasis>
                                                     ]
                                                  :: 
@@ -112,9 +112,9 @@
                                                     myint
                                                 <emphasis>
                                                      [
-                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                                     <emphasis>
-                                                        integer
+                                                        integer 
                                                 <emphasis>
                                                     ]
                                                  :: 
@@ -281,9 +281,9 @@
                                                 )
                                                 <emphasis>
                                                      [
-                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                                     <emphasis>
-                                                        real
+                                                        real 
                                                 <emphasis>
                                                     ]
                                                  :: 
@@ -299,9 +299,9 @@
                                                 )
                                                 <emphasis>
                                                      [
-                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real" reftype="type" typename="">
+                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="real " reftype="type" typename="">
                                                     <emphasis>
-                                                        real
+                                                        real 
                                                 <emphasis>
                                                     ]
                                                  :: 
@@ -314,9 +314,9 @@
                                                     myint
                                                 <emphasis>
                                                      [
-                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="integer" reftype="type" typename="">
+                                                <pending_xref modname="generic" refdomain="f" refexplicit="False" reftarget="integer " reftype="type" typename="">
                                                     <emphasis>
-                                                        integer
+                                                        integer 
                                                 <emphasis>
                                                     ]
                                                  :: 


### PR DESCRIPTION
Since b2d6ced, tests are failing because of additional whitespaces. This updates references to make the tests pass.