### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ maintainer_email = author_email
 license = "CeCiLL-A"
 url = "http://sphinx-fortran.readthedocs.org"
 classifiers = [
+        "Framework :: Sphinx :: Extension",
         ("License :: OSI Approved :: CEA CNRS Inria Logiciel "
          "Libre License, version 2.1 (CeCILL-2.1)"),
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).

You may also want to add the [sphinx-extension](https://github.com/topics/sphinx-extension) repo topic, there are over 200 other extensions using it.