### PR TITLE
Fix FortranDomain.merge_domaindata so parallel reads keep Fortran obj…

### DIFF
--- a/sphinxfortran/__init__.py
+++ b/sphinxfortran/__init__.py
@@ -3,7 +3,7 @@
 
 
 """
-# Copyright or © or Copr. Actimar/IFREMER (2010-2019)
+# Copyright or © or Copr. Actimar/IFREMER (2010-2026)
 #
 # This software is a computer program whose purpose is to provide
 # utilities for handling oceanographic and atmospheric data,
@@ -36,8 +36,8 @@
 # knowledge of the CeCILL license and that you accept its terms.
 #
 
-__version__ = '1.1.2'
-__date__ = "2019-11-20"
+__version__ = '1.1.3'
+__date__ = "2026-07-02"
 __author__ = 'Stephane Raynaud'
 __email__ = 'stephane.raynaud@gmail.com'
-__copyright__ = 'Copyright (c) 2010-2019 Actimar/IFREMER'
+__copyright__ = 'Copyright (c) 2010-2026 Actimar/IFREMER'

--- a/sphinxfortran/fortran_domain.py
+++ b/sphinxfortran/fortran_domain.py
@@ -1266,16 +1266,16 @@ class FortranDomain(Domain):
 
     def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:
         ourNames = self.data['modules']
-        for name, docname in otherdata['modules'].items():
-            if docname in docnames:
-                if name not in outNames:
-                    outNames[name] = docname
+        for name, data in otherdata['modules'].items():
+            if data[0] in docnames:
+                if name not in ourNames:
+                    ourNames[name] = data
 
         ourNames = self.data['objects']
-        for name, docname in otherdata['objects'].items():
-            if docname in docnames:
-                if name not in outNames:
-                    outNames[name] = docname
+        for name, data in otherdata['objects'].items():
+            if data[0] in docnames:
+                if name not in ourNames:
+                    ourNames[name] = data
 
     def resolve_xref(self, env, fromdocname, builder,
                      type, target, node, contnode):


### PR DESCRIPTION
This fixes a bug with parallel reads that surfaced some time ago with newer Sphinx versions.

Under parallel reads (sphinx-build -j), each worker builds partial domain data that the main process merges via Domain.merge_domaindata(). The implementation was broken two ways and silently merged nothing:
      
- it iterated `for name, docname in otherdata[...].items()`, but the stored value is a tuple (objects: (docname, objtype); modules: (docname, synopsis, platform, deprecated)). So `docname` was the whole tuple and `if docname in docnames` was always false.
- it referenced an undefined name `outNames` (typo for `ourNames`), which would have raised NameError had the guard ever passed.
      
The net effect was that parallel builds discarded all Fortran domain data: `f:func:/:f:mod:/:f:subr`: cross-references rendered as plain text instead of links and objects.inv contained no `f:` entries (the self-anchor headerlinks kept working, which masked it). Serial builds were unaffected.
      
Iterate using data[0] as the docname and copy the full tuple value.
      
This also bumps the version to 1.1.3 to trigger updates
